### PR TITLE
solve : 230201 yechankun 프로그래머스 순위 & solve : 230201 yechankun 프로그래머스 방문 길이

### DIFF
--- a/yechankun/230201_yechankun_programmers_방문 길이.py
+++ b/yechankun/230201_yechankun_programmers_방문 길이.py
@@ -1,0 +1,20 @@
+# https://school.programmers.co.kr/learn/courses/30/lessons/49994
+# 예상 알고리즘: 방향 벡터
+# 베스트 알고리즘: 방향 벡터
+
+def solution(dirs):
+    drc = {'U':(1, 0), 'D':(-1, 0), 'R':(0, 1), 'L':(0,-1)}
+    visited = set()
+    r, c = 0, 0
+    for op in dirs:
+        dr, dc = drc[op]
+        nr = r + dr
+        nc = c + dc
+        if -5 <= nr <= 5 and -5 <= nc <= 5:
+            visited.update([(nr, nc, r, c), (r, c, nr, nc)])
+            r, c = nr, nc
+    return len(visited) // 2
+
+
+print(solution("ULURRDLLU"))
+print(solution("LULLLLLLU"))

--- a/yechankun/230201_yechankun_programmers_순위.py
+++ b/yechankun/230201_yechankun_programmers_순위.py
@@ -1,0 +1,45 @@
+# https://school.programmers.co.kr/learn/courses/30/lessons/49191
+# 예상 알고리즘: 그래프, BFS, 플로이드 워셜
+# 베스트 알고리즘: 그래프 순회
+
+from collections import defaultdict
+def solution(n, results):
+    answer = 0
+
+    winDict = defaultdict(set)
+    loseDict = defaultdict(set)
+
+    for w, l in results:
+        winDict[w].add(l)
+        loseDict[l].add(w)
+
+    resultWinsDict = defaultdict(set)
+    resultLoseDict = defaultdict(set)
+
+    for i in range(1, n+1):
+        bfs(i, resultWinsDict, winDict)
+        bfs(i, resultLoseDict, loseDict)
+    
+    for i in resultWinsDict:
+        if len(resultWinsDict[i]) + len(resultLoseDict[i]) == n-1:
+            answer += 1
+    return answer
+
+def bfs(start, resultDict, searchDict):
+    queue = [start]
+    visited = set([start])
+    while queue:
+        nextQueue = []
+        for node in queue:
+            for i in searchDict[node]:
+                if i in visited:
+                    continue
+                visited.add(i)
+                resultDict[i].add(node)
+                for j in resultDict[node]:
+                    resultDict[i].add(j)
+                nextQueue.append(i)
+        queue = nextQueue
+
+
+print(solution(	5, [[4, 3], [4, 2], [3, 2], [1, 2], [2, 5]]))


### PR DESCRIPTION
<풀이 과정>
1. BFS로 푼다.
2. 인접한 승자와 패자 디폴트 딕셔너리를 사용한다.
3. 결과를 저장할 set을 이용한 디폴트 딕셔너리를 사용한다.
4. bfs를 통해 노드별 승자 모임, 노드별 패자 모임을 구할 것이다.
5. 패자 딕셔너리의 경우 패자들을 순회하며 패자 결과의 승자들을 저장한다. 
6. 승자 딕셔너리의 경우 승자들을 순회하며 승자 결과의 패자들을 저장한다.
7. 두 결과 딕셔너리의 같은 각 원소별 길이의 합이 전체 길이(n) - 1과 같으면 정답을 1 올린다.
8. answer를 출력한다.

---

<풀이 과정>
1. 방향 벡터와 집합 자료형을 이용해 푼다.
2. 각 명령어를 딕셔너리로 해석해 튜플로 행과 열의 변화를 저장한다.
3. dirs를 한 글자씩 순회하며 새로운 행과 열을 구한다.
4. -5와 5의 범위를 넘지 않으면 visited에 행과 열 이동한 점들을 양 쪽 다 저장한다. 이는 길을 저장하기 위함이다.
5. 모두 순회 후 visited의 길이의 절반이 처음으로 이동한 길의 개수다.